### PR TITLE
hotfix(cli): specify key parameter for memory obfuscation

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -66,7 +66,7 @@ def obfuscate_wasm(input_path: str, output_path: str, args: argparse.Namespace) 
         obfuscator.name_obfuscation()
         did_something = True
     if args.memory:
-        obfuscator.memory_obfuscation()
+        obfuscator.memory_obfuscation(key=0)
         did_something = True
     if not did_something:
         print("No obfuscation level selected. Use --list to see options.")


### PR DESCRIPTION
The previous PR #6 introduced an error in memory obfuscation due to an unintended removal of `key=0`. **This commit restores the key** to ensure **correct functionality** and prevent related issues.